### PR TITLE
feat(dashboard): MonthlyProgressSummaryとActivityHeatmapを追加

### DIFF
--- a/src/components/dashboard/ActivityHeatmap.tsx
+++ b/src/components/dashboard/ActivityHeatmap.tsx
@@ -1,0 +1,329 @@
+import React, { useMemo } from 'react';
+import { Box, Typography, Tooltip, useTheme } from '@mui/material';
+import { motion } from 'framer-motion';
+import { TimeEntry } from '../../types';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { GlassCard } from '../ui/modern/StyledComponents';
+import {
+  generateHeatmapData,
+  getRolling12MonthRange,
+  HeatmapDay,
+} from '../../utils/analytics/heatmap';
+
+interface ActivityHeatmapProps {
+  timeEntries: TimeEntry[];
+  onDayClick?: (date: Date, hours: number) => void;
+}
+
+// ヒートマップのカラーを動的に生成（テーマのプライマリカラーを使用）
+const getHeatmapColors = (theme: ReturnType<typeof useTheme>) => {
+  const isDark = theme.palette.mode === 'dark';
+
+  if (isDark) {
+    // ダークモード: 暗い→明るいへのグラデーション
+    return {
+      0: '#1f2937', // grey-800
+      1: '#1e3a8a', // blue-900
+      2: '#2563eb', // blue-600
+      3: '#3b82f6', // blue-500 (primary)
+      4: '#60a5fa', // blue-400
+    };
+  }
+
+  // ライトモード: 薄い→濃いへのグラデーション
+  return {
+    0: '#f3f4f6', // grey-100
+    1: '#bfdbfe', // blue-200
+    2: '#60a5fa', // blue-400
+    3: '#3b82f6', // blue-500 (primary)
+    4: '#1d4ed8', // blue-700 (primary.dark)
+  };
+};
+
+// 月の短縮名
+const MONTH_NAMES = {
+  en: [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ],
+  ja: [
+    '1月',
+    '2月',
+    '3月',
+    '4月',
+    '5月',
+    '6月',
+    '7月',
+    '8月',
+    '9月',
+    '10月',
+    '11月',
+    '12月',
+  ],
+};
+
+// 曜日ラベル（月、水、金のみ表示）
+const DAY_LABELS = {
+  en: ['', 'Mon', '', 'Wed', '', 'Fri', ''],
+  ja: ['', '月', '', '水', '', '金', ''],
+};
+
+export const ActivityHeatmap: React.FC<ActivityHeatmapProps> = ({
+  timeEntries,
+  onDayClick,
+}) => {
+  const theme = useTheme();
+  const { t, language } = useLanguage();
+
+  const isEnglish = language === 'en';
+  const colors = getHeatmapColors(theme);
+
+  // ヒートマップデータを生成
+  const { heatmapData, monthLabels } = useMemo(() => {
+    const { start, end } = getRolling12MonthRange();
+    const data = generateHeatmapData(timeEntries, start, end);
+
+    // 月ラベルの位置を計算
+    const labels: { month: number; weekIndex: number }[] = [];
+    let currentMonth = -1;
+
+    data.forEach((week, weekIndex) => {
+      const firstValidDay = week.days.find(
+        (day): day is HeatmapDay => day !== null
+      );
+      if (firstValidDay) {
+        const month = firstValidDay.date.getMonth();
+        if (month !== currentMonth) {
+          labels.push({ month, weekIndex });
+          currentMonth = month;
+        }
+      }
+    });
+
+    return { heatmapData: data, monthLabels: labels };
+  }, [timeEntries]);
+
+  // 日付をフォーマット
+  const formatDate = (date: Date): string => {
+    if (isEnglish) {
+      return date.toLocaleDateString('en-US', {
+        weekday: 'short',
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      });
+    }
+    return `${date.getFullYear()}年${date.getMonth() + 1}月${date.getDate()}日（${['日', '月', '火', '水', '木', '金', '土'][date.getDay()]}）`;
+  };
+
+  // ツールチップの内容
+  const getTooltipContent = (day: HeatmapDay): string => {
+    const dateStr = formatDate(day.date);
+    const hoursStr = isEnglish
+      ? `${day.hours.toFixed(1)} hours`
+      : `${day.hours.toFixed(1)}時間`;
+    return `${dateStr}: ${hoursStr}`;
+  };
+
+  const cellSize = 12;
+  const cellGap = 3;
+  const dayLabelWidth = 30;
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5, delay: 0.2 }}
+    >
+      <GlassCard
+        sx={{
+          p: { xs: 2, md: 3 },
+          overflow: 'hidden',
+        }}
+      >
+        {/* ヘッダー */}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 2,
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {t('dashboard.heatmap.title')}
+          </Typography>
+
+          {/* 凡例 */}
+          <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+            <Typography variant="caption" color="text.secondary">
+              {t('dashboard.heatmap.less')}
+            </Typography>
+            {[0, 1, 2, 3, 4].map((level) => (
+              <Box
+                key={level}
+                sx={{
+                  width: 12,
+                  height: 12,
+                  borderRadius: '2px',
+                  bgcolor: colors[level as keyof typeof colors],
+                }}
+              />
+            ))}
+            <Typography variant="caption" color="text.secondary">
+              {t('dashboard.heatmap.more')}
+            </Typography>
+          </Box>
+        </Box>
+
+        {/* ヒートマップ本体 */}
+        <Box
+          sx={{
+            overflowX: 'auto',
+            overflowY: 'hidden',
+            pb: 1,
+          }}
+        >
+          <Box
+            sx={{
+              display: 'flex',
+              flexDirection: 'column',
+              minWidth: 'fit-content',
+            }}
+          >
+            {/* 月ラベル */}
+            <Box
+              sx={{
+                display: 'flex',
+                ml: `${dayLabelWidth}px`,
+                mb: 0.5,
+              }}
+            >
+              {monthLabels.map(({ month, weekIndex }, index) => {
+                const nextLabelIndex = monthLabels[index + 1]?.weekIndex;
+                const width = nextLabelIndex
+                  ? (nextLabelIndex - weekIndex) * (cellSize + cellGap)
+                  : 4 * (cellSize + cellGap);
+
+                return (
+                  <Box
+                    key={`${month}-${weekIndex}`}
+                    sx={{
+                      width: width,
+                      flexShrink: 0,
+                    }}
+                  >
+                    <Typography
+                      variant="caption"
+                      color="text.secondary"
+                      sx={{ fontSize: '10px' }}
+                    >
+                      {isEnglish
+                        ? MONTH_NAMES.en[month]
+                        : MONTH_NAMES.ja[month]}
+                    </Typography>
+                  </Box>
+                );
+              })}
+            </Box>
+
+            {/* グリッド本体 */}
+            <Box sx={{ display: 'flex' }}>
+              {/* 曜日ラベル */}
+              <Box
+                sx={{
+                  display: 'flex',
+                  flexDirection: 'column',
+                  width: `${dayLabelWidth}px`,
+                  flexShrink: 0,
+                }}
+              >
+                {(isEnglish ? DAY_LABELS.en : DAY_LABELS.ja).map(
+                  (label, index) => (
+                    <Box
+                      key={index}
+                      sx={{
+                        height: cellSize + cellGap,
+                        display: 'flex',
+                        alignItems: 'center',
+                      }}
+                    >
+                      <Typography
+                        variant="caption"
+                        color="text.secondary"
+                        sx={{ fontSize: '10px' }}
+                      >
+                        {label}
+                      </Typography>
+                    </Box>
+                  )
+                )}
+              </Box>
+
+              {/* 週のカラム */}
+              <Box sx={{ display: 'flex', gap: `${cellGap}px` }}>
+                {heatmapData.map((week, weekIndex) => (
+                  <Box
+                    key={weekIndex}
+                    sx={{
+                      display: 'flex',
+                      flexDirection: 'column',
+                      gap: `${cellGap}px`,
+                    }}
+                  >
+                    {week.days.map((day, dayIndex) => (
+                      <Tooltip
+                        key={dayIndex}
+                        title={day ? getTooltipContent(day) : ''}
+                        arrow
+                        placement="top"
+                        disableHoverListener={!day}
+                      >
+                        <Box
+                          onClick={() => {
+                            if (day && onDayClick) {
+                              onDayClick(day.date, day.hours);
+                            }
+                          }}
+                          sx={{
+                            width: cellSize,
+                            height: cellSize,
+                            borderRadius: '2px',
+                            bgcolor: day ? colors[day.level] : 'transparent',
+                            cursor: day && onDayClick ? 'pointer' : 'default',
+                            transition: 'transform 0.1s, box-shadow 0.1s',
+                            '&:hover': day
+                              ? {
+                                  transform: 'scale(1.2)',
+                                  boxShadow: `0 0 4px ${colors[day.level]}`,
+                                }
+                              : {},
+                          }}
+                          aria-label={
+                            day
+                              ? `${formatDate(day.date)}: ${day.hours.toFixed(1)}${isEnglish ? ' hours' : '時間'}`
+                              : undefined
+                          }
+                        />
+                      </Tooltip>
+                    ))}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+          </Box>
+        </Box>
+      </GlassCard>
+    </motion.div>
+  );
+};

--- a/src/components/dashboard/ActivityHeatmap.tsx
+++ b/src/components/dashboard/ActivityHeatmap.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import { Box, Typography, Tooltip, useTheme } from '@mui/material';
+import { Box, Typography, Tooltip, useTheme, Theme } from '@mui/material';
 import { motion } from 'framer-motion';
 import { TimeEntry } from '../../types';
 import { useLanguage } from '../../contexts/LanguageContext';
@@ -16,7 +16,7 @@ interface ActivityHeatmapProps {
 }
 
 // ヒートマップのカラーを動的に生成（テーマのプライマリカラーを使用）
-const getHeatmapColors = (theme: ReturnType<typeof useTheme>) => {
+const getHeatmapColors = (theme: Theme) => {
   const isDark = theme.palette.mode === 'dark';
 
   if (isDark) {

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 import { Box, Grid, Paper, useTheme, useMediaQuery } from '@mui/material';
 import { Project, TimeEntry } from '../../types';
-import { DailySummary } from './DailySummary';
+import { MonthlyProgressSummary } from './MonthlyProgressSummary';
+import { ActivityHeatmap } from './ActivityHeatmap';
 import { WeeklySummary } from './WeeklySummary';
 import { MonthlySummary } from './MonthlySummary';
 import { ProjectProgressView } from './ProjectProgressView';
@@ -51,9 +52,14 @@ export const Dashboard: React.FC<DashboardProps> = ({
             : theme.palette.background.default,
       }}
     >
-      {/* 日次サマリー */}
-      <Box sx={{ mb: 4 }}>
-        <DailySummary projects={projects} timeEntries={timeEntries} />
+      {/* 月間進捗サマリー */}
+      <Box sx={{ mb: 3 }}>
+        <MonthlyProgressSummary projects={projects} timeEntries={timeEntries} />
+      </Box>
+
+      {/* 活動ヒートマップ */}
+      <Box sx={{ mb: 3 }}>
+        <ActivityHeatmap timeEntries={timeEntries} />
       </Box>
 
       {/* ウィジェット領域 */}

--- a/src/components/dashboard/MonthlyProgressSummary.tsx
+++ b/src/components/dashboard/MonthlyProgressSummary.tsx
@@ -1,0 +1,370 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Typography,
+  CircularProgress,
+  Grid,
+  useTheme,
+} from '@mui/material';
+import {
+  TrendingUp,
+  TrendingDown,
+  TrendingFlat,
+  CalendarToday,
+  Speed,
+} from '@mui/icons-material';
+import { motion } from 'framer-motion';
+import { Project, TimeEntry } from '../../types';
+import { useLanguage } from '../../contexts/LanguageContext';
+import { useSettingsContext } from '../../contexts/SettingsContext';
+import { GlassCard } from '../ui/modern/StyledComponents';
+import {
+  calculateTotalMonthlyTarget,
+  calculateRemainingWorkingDays,
+  calculateMonthOverMonthChange,
+} from '../../utils/analytics';
+import { getDailyWorkHours } from '../../utils/analytics';
+
+interface MonthlyProgressSummaryProps {
+  projects: Project[];
+  timeEntries: TimeEntry[];
+}
+
+export const MonthlyProgressSummary: React.FC<MonthlyProgressSummaryProps> = ({
+  projects,
+  timeEntries,
+}) => {
+  const theme = useTheme();
+  const { t, language } = useLanguage();
+  const { settings } = useSettingsContext();
+
+  const isEnglish = language === 'en';
+
+  // 今月の作業時間を計算
+  const monthlyData = useMemo(() => {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1);
+    const today = new Date();
+
+    let totalHours = 0;
+    const currentDate = new Date(startOfMonth);
+
+    while (currentDate <= today) {
+      totalHours += getDailyWorkHours(timeEntries, new Date(currentDate));
+      currentDate.setDate(currentDate.getDate() + 1);
+    }
+
+    return totalHours;
+  }, [timeEntries]);
+
+  // 目標時間の合計
+  const totalTargetHours = useMemo(() => {
+    return calculateTotalMonthlyTarget(
+      projects,
+      settings.workHours.baseMonthlyHours
+    );
+  }, [projects, settings.workHours.baseMonthlyHours]);
+
+  // 進捗率
+  const progressPercentage = useMemo(() => {
+    if (totalTargetHours === 0) return 0;
+    return Math.min(Math.round((monthlyData / totalTargetHours) * 100), 100);
+  }, [monthlyData, totalTargetHours]);
+
+  // 残り営業日数
+  const remainingDays = useMemo(() => {
+    return calculateRemainingWorkingDays();
+  }, []);
+
+  // 必要なペース（残り時間 / 残り日数）
+  const requiredPace = useMemo(() => {
+    if (remainingDays === 0) return 0;
+    const remainingHours = Math.max(0, totalTargetHours - monthlyData);
+    return Number((remainingHours / remainingDays).toFixed(1));
+  }, [totalTargetHours, monthlyData, remainingDays]);
+
+  // 先月比
+  const monthOverMonth = useMemo(() => {
+    return calculateMonthOverMonthChange(timeEntries);
+  }, [timeEntries]);
+
+  // 進捗バーの色を決定
+  const getProgressColor = () => {
+    if (progressPercentage >= 100) return theme.palette.success.main;
+    if (progressPercentage >= 90) return theme.palette.warning.main;
+    return theme.palette.primary.main;
+  };
+
+  // トレンドアイコンを取得
+  const getTrendIcon = () => {
+    switch (monthOverMonth.trend) {
+      case 'up':
+        return <TrendingUp sx={{ color: theme.palette.success.main }} />;
+      case 'down':
+        return <TrendingDown sx={{ color: theme.palette.error.main }} />;
+      default:
+        return <TrendingFlat sx={{ color: theme.palette.text.secondary }} />;
+    }
+  };
+
+  // 月の表示
+  const getMonthDisplay = () => {
+    const now = new Date();
+    if (isEnglish) {
+      return now.toLocaleDateString('en-US', {
+        month: 'long',
+        year: 'numeric',
+      });
+    }
+    return `${now.getFullYear()}年${now.getMonth() + 1}月`;
+  };
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.5 }}
+    >
+      <GlassCard sx={{ p: { xs: 2, md: 3 } }}>
+        {/* ヘッダー */}
+        <Box
+          sx={{
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            mb: 3,
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            {t('dashboard.monthly.summary.title')}
+          </Typography>
+          <Typography variant="body2" color="text.secondary">
+            {getMonthDisplay()}
+          </Typography>
+        </Box>
+
+        <Grid container spacing={3} alignItems="center">
+          {/* 大きなプログレスリング */}
+          <Grid item xs={12} md={4}>
+            <Box
+              sx={{
+                display: 'flex',
+                justifyContent: 'center',
+                alignItems: 'center',
+              }}
+            >
+              <motion.div
+                initial={{ scale: 0.8, opacity: 0 }}
+                animate={{ scale: 1, opacity: 1 }}
+                transition={{ delay: 0.2, type: 'spring', stiffness: 100 }}
+              >
+                <Box sx={{ position: 'relative', display: 'inline-flex' }}>
+                  {/* 背景の円 */}
+                  <CircularProgress
+                    variant="determinate"
+                    value={100}
+                    size={140}
+                    thickness={4}
+                    sx={{
+                      color:
+                        theme.palette.mode === 'dark'
+                          ? 'rgba(255,255,255,0.1)'
+                          : 'rgba(0,0,0,0.08)',
+                    }}
+                  />
+                  {/* 進捗の円 */}
+                  <CircularProgress
+                    variant="determinate"
+                    value={progressPercentage}
+                    size={140}
+                    thickness={4}
+                    sx={{
+                      color: getProgressColor(),
+                      position: 'absolute',
+                      left: 0,
+                      '& .MuiCircularProgress-circle': {
+                        strokeLinecap: 'round',
+                        transition: 'stroke-dasharray 1s ease-out',
+                      },
+                    }}
+                  />
+                  {/* 中央のテキスト */}
+                  <Box
+                    sx={{
+                      position: 'absolute',
+                      top: 0,
+                      left: 0,
+                      bottom: 0,
+                      right: 0,
+                      display: 'flex',
+                      flexDirection: 'column',
+                      alignItems: 'center',
+                      justifyContent: 'center',
+                    }}
+                  >
+                    <motion.div
+                      initial={{ scale: 0 }}
+                      animate={{ scale: 1 }}
+                      transition={{ delay: 0.5, type: 'spring' }}
+                    >
+                      <Typography
+                        variant="h3"
+                        sx={{
+                          fontWeight: 700,
+                          color: getProgressColor(),
+                          lineHeight: 1,
+                        }}
+                      >
+                        {progressPercentage}
+                      </Typography>
+                    </motion.div>
+                    <Typography
+                      variant="body2"
+                      color="text.secondary"
+                      sx={{ fontWeight: 500 }}
+                    >
+                      %
+                    </Typography>
+                  </Box>
+                </Box>
+              </motion.div>
+            </Box>
+          </Grid>
+
+          {/* 統計情報 */}
+          <Grid item xs={12} md={8}>
+            <Grid container spacing={2}>
+              {/* 作業時間 / 目標時間 */}
+              <Grid item xs={12}>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 1,
+                    border: `1px solid ${theme.palette.divider}`,
+                  }}
+                >
+                  <Typography
+                    variant="body2"
+                    color="text.secondary"
+                    gutterBottom
+                  >
+                    {t('dashboard.monthly.summary.worked')} /{' '}
+                    {t('dashboard.monthly.summary.target')}
+                  </Typography>
+                  <Typography variant="h5" sx={{ fontWeight: 600 }}>
+                    {monthlyData.toFixed(1)}h{' '}
+                    <Typography
+                      component="span"
+                      variant="body1"
+                      color="text.secondary"
+                    >
+                      / {totalTargetHours.toFixed(1)}h
+                    </Typography>
+                  </Typography>
+                </Box>
+              </Grid>
+
+              {/* 残り営業日 */}
+              <Grid item xs={6}>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 1,
+                    border: `1px solid ${theme.palette.divider}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
+                  <CalendarToday
+                    fontSize="small"
+                    sx={{ color: theme.palette.text.secondary }}
+                  />
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('dashboard.monthly.summary.remaining.days')}
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                      {remainingDays}
+                      {isEnglish ? ' days' : '日'}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Grid>
+
+              {/* 必要ペース */}
+              <Grid item xs={6}>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 1,
+                    border: `1px solid ${theme.palette.divider}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    gap: 1,
+                  }}
+                >
+                  <Speed
+                    fontSize="small"
+                    sx={{ color: theme.palette.text.secondary }}
+                  />
+                  <Box>
+                    <Typography variant="body2" color="text.secondary">
+                      {t('dashboard.monthly.summary.required.pace')}
+                    </Typography>
+                    <Typography variant="h6" sx={{ fontWeight: 600 }}>
+                      {requiredPace}h{t('dashboard.monthly.summary.per.day')}
+                    </Typography>
+                  </Box>
+                </Box>
+              </Grid>
+
+              {/* 先月比 */}
+              <Grid item xs={12}>
+                <Box
+                  sx={{
+                    p: 2,
+                    borderRadius: 1,
+                    border: `1px solid ${theme.palette.divider}`,
+                    display: 'flex',
+                    alignItems: 'center',
+                    justifyContent: 'space-between',
+                  }}
+                >
+                  <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
+                    {getTrendIcon()}
+                    <Typography variant="body2" color="text.secondary">
+                      {t('dashboard.monthly.summary.vs.last.month')}
+                    </Typography>
+                  </Box>
+                  <Typography
+                    variant="body1"
+                    sx={{
+                      fontWeight: 600,
+                      color:
+                        monthOverMonth.trend === 'up'
+                          ? theme.palette.success.main
+                          : monthOverMonth.trend === 'down'
+                            ? theme.palette.error.main
+                            : theme.palette.text.secondary,
+                    }}
+                  >
+                    {monthOverMonth.trend !== 'flat' && (
+                      <>
+                        {monthOverMonth.hoursChange > 0 ? '+' : ''}
+                        {monthOverMonth.hoursChange}h (
+                        {monthOverMonth.percentageChange > 0 ? '+' : ''}
+                        {monthOverMonth.percentageChange}%)
+                      </>
+                    )}
+                    {monthOverMonth.trend === 'flat' && '—'}
+                  </Typography>
+                </Box>
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      </GlassCard>
+    </motion.div>
+  );
+};

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -140,6 +140,23 @@ export const translations = {
     'time.last.month': '先月',
     'timer.export.success': '作業記録のエクスポートが完了しました',
     'timer.export.error': 'エクスポートに失敗しました',
+
+    // Monthly Progress Summary
+    'dashboard.monthly.summary.title': '月間進捗サマリー',
+    'dashboard.monthly.summary.worked': '作業時間',
+    'dashboard.monthly.summary.target': '目標時間',
+    'dashboard.monthly.summary.remaining.days': '残り営業日',
+    'dashboard.monthly.summary.required.pace': '必要ペース',
+    'dashboard.monthly.summary.vs.last.month': '先月比',
+    'dashboard.monthly.summary.per.day': '/日',
+    'dashboard.monthly.summary.on.track': '順調',
+    'dashboard.monthly.summary.behind': '遅れ',
+
+    // Activity Heatmap
+    'dashboard.heatmap.title': '活動ヒートマップ',
+    'dashboard.heatmap.less': '少ない',
+    'dashboard.heatmap.more': '多い',
+    'dashboard.heatmap.hours': '{hours}時間',
   },
   en: {
     // Common
@@ -282,5 +299,22 @@ export const translations = {
     'time.last.month': 'Last Month',
     'timer.export.success': 'Time entries exported successfully',
     'timer.export.error': 'Failed to export time entries',
+
+    // Monthly Progress Summary
+    'dashboard.monthly.summary.title': 'Monthly Progress Summary',
+    'dashboard.monthly.summary.worked': 'Hours Worked',
+    'dashboard.monthly.summary.target': 'Target Hours',
+    'dashboard.monthly.summary.remaining.days': 'Working Days Left',
+    'dashboard.monthly.summary.required.pace': 'Required Pace',
+    'dashboard.monthly.summary.vs.last.month': 'vs Last Month',
+    'dashboard.monthly.summary.per.day': '/day',
+    'dashboard.monthly.summary.on.track': 'On Track',
+    'dashboard.monthly.summary.behind': 'Behind',
+
+    // Activity Heatmap
+    'dashboard.heatmap.title': 'Activity Heatmap',
+    'dashboard.heatmap.less': 'Less',
+    'dashboard.heatmap.more': 'More',
+    'dashboard.heatmap.hours': '{hours} hours',
   },
 };

--- a/src/utils/__tests__/heatmap.test.ts
+++ b/src/utils/__tests__/heatmap.test.ts
@@ -1,0 +1,212 @@
+import {
+  calculateHeatmapLevel,
+  getRolling12MonthRange,
+  generateHeatmapData,
+} from '../analytics/heatmap';
+import { TimeEntry } from '../../types';
+
+// テスト用のタイムエントリーデータ
+const createTimeEntry = (
+  projectId: string,
+  startTime: string,
+  endTime: string
+): TimeEntry => ({
+  id: `entry-${Math.random().toString(36).substr(2, 9)}`,
+  projectId,
+  startTime,
+  endTime,
+  description: '',
+  createdAt: new Date().toISOString(),
+  updatedAt: new Date().toISOString(),
+});
+
+describe('heatmap ユーティリティ', () => {
+  describe('calculateHeatmapLevel', () => {
+    test('0時間の場合はレベル0を返す', () => {
+      expect(calculateHeatmapLevel(0)).toBe(0);
+    });
+
+    test('0.1〜2時間未満の場合はレベル1を返す', () => {
+      expect(calculateHeatmapLevel(0.1)).toBe(1);
+      expect(calculateHeatmapLevel(1)).toBe(1);
+      expect(calculateHeatmapLevel(1.9)).toBe(1);
+    });
+
+    test('2〜4時間未満の場合はレベル2を返す', () => {
+      expect(calculateHeatmapLevel(2)).toBe(2);
+      expect(calculateHeatmapLevel(3)).toBe(2);
+      expect(calculateHeatmapLevel(3.9)).toBe(2);
+    });
+
+    test('4〜6時間未満の場合はレベル3を返す', () => {
+      expect(calculateHeatmapLevel(4)).toBe(3);
+      expect(calculateHeatmapLevel(5)).toBe(3);
+      expect(calculateHeatmapLevel(5.9)).toBe(3);
+    });
+
+    test('6時間以上の場合はレベル4を返す', () => {
+      expect(calculateHeatmapLevel(6)).toBe(4);
+      expect(calculateHeatmapLevel(8)).toBe(4);
+      expect(calculateHeatmapLevel(12)).toBe(4);
+    });
+  });
+
+  describe('getRolling12MonthRange', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2025-12-27T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('今日を終了日として12ヶ月前を開始日とする', () => {
+      const { start, end } = getRolling12MonthRange();
+
+      expect(end.getFullYear()).toBe(2025);
+      expect(end.getMonth()).toBe(11); // December
+      expect(end.getDate()).toBe(27);
+
+      expect(start.getFullYear()).toBe(2024);
+      expect(start.getMonth()).toBe(11); // December
+      expect(start.getDate()).toBe(28);
+    });
+
+    test('開始日は終了日のちょうど1年前の翌日', () => {
+      const { start, end } = getRolling12MonthRange();
+
+      const diffInDays = Math.round(
+        (end.getTime() - start.getTime()) / (1000 * 60 * 60 * 24)
+      );
+
+      // 365日または364日（うるう年考慮）
+      expect(diffInDays).toBeGreaterThanOrEqual(364);
+      expect(diffInDays).toBeLessThanOrEqual(366);
+    });
+  });
+
+  describe('generateHeatmapData', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date('2025-01-15T12:00:00Z'));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('空のタイムエントリーでも週の配列を返す', () => {
+      const startDate = new Date('2025-01-01');
+      const endDate = new Date('2025-01-14');
+
+      const result = generateHeatmapData([], startDate, endDate);
+
+      expect(result.length).toBeGreaterThan(0);
+      expect(Array.isArray(result[0].days)).toBe(true);
+    });
+
+    test('各週は7日分のデータを持つ', () => {
+      const startDate = new Date('2025-01-06'); // 月曜日
+      const endDate = new Date('2025-01-12'); // 日曜日
+
+      const result = generateHeatmapData([], startDate, endDate);
+
+      expect(result.length).toBeGreaterThanOrEqual(1);
+      result.forEach((week) => {
+        expect(week.days.length).toBe(7);
+      });
+    });
+
+    test('タイムエントリーがある日は時間が計算される', () => {
+      const timeEntries = [
+        createTimeEntry('p1', '2025-01-10T09:00:00Z', '2025-01-10T13:00:00Z'), // 4時間
+      ];
+      const startDate = new Date('2025-01-06');
+      const endDate = new Date('2025-01-12');
+
+      const result = generateHeatmapData(timeEntries, startDate, endDate);
+
+      // 1月10日（金曜日）のデータを探す
+      let found = false;
+      for (const week of result) {
+        for (const day of week.days) {
+          if (day && day.date.getDate() === 10 && day.date.getMonth() === 0) {
+            expect(day.hours).toBe(4);
+            expect(day.level).toBe(3); // 4時間はレベル3（4〜6時間の範囲）
+            found = true;
+          }
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    test('同じ日に複数のエントリーがある場合は合計される', () => {
+      const timeEntries = [
+        createTimeEntry('p1', '2025-01-10T09:00:00Z', '2025-01-10T11:00:00Z'), // 2時間
+        createTimeEntry('p1', '2025-01-10T13:00:00Z', '2025-01-10T16:00:00Z'), // 3時間
+      ];
+      const startDate = new Date('2025-01-06');
+      const endDate = new Date('2025-01-12');
+
+      const result = generateHeatmapData(timeEntries, startDate, endDate);
+
+      let found = false;
+      for (const week of result) {
+        for (const day of week.days) {
+          if (day && day.date.getDate() === 10 && day.date.getMonth() === 0) {
+            expect(day.hours).toBe(5);
+            expect(day.level).toBe(3); // 5時間はレベル3
+            found = true;
+          }
+        }
+      }
+      expect(found).toBe(true);
+    });
+
+    test('期間外のエントリーは含まれない', () => {
+      const timeEntries = [
+        createTimeEntry('p1', '2025-01-05T09:00:00Z', '2025-01-05T17:00:00Z'), // 期間外
+        createTimeEntry('p1', '2025-01-10T09:00:00Z', '2025-01-10T13:00:00Z'), // 期間内
+      ];
+      const startDate = new Date('2025-01-06');
+      const endDate = new Date('2025-01-12');
+
+      const result = generateHeatmapData(timeEntries, startDate, endDate);
+
+      // 1月5日のデータは含まれないはず
+      let foundOutOfRangeDate = false;
+      for (const week of result) {
+        for (const day of week.days) {
+          if (day && day.date.getDate() === 5 && day.date.getMonth() === 0) {
+            foundOutOfRangeDate = true;
+          }
+        }
+      }
+      expect(foundOutOfRangeDate).toBe(false);
+    });
+
+    test('HeatmapDayの構造が正しい', () => {
+      const timeEntries = [
+        createTimeEntry('p1', '2025-01-10T09:00:00Z', '2025-01-10T13:00:00Z'),
+      ];
+      const startDate = new Date('2025-01-06');
+      const endDate = new Date('2025-01-12');
+
+      const result = generateHeatmapData(timeEntries, startDate, endDate);
+
+      for (const week of result) {
+        for (const day of week.days) {
+          if (day !== null) {
+            expect(day).toHaveProperty('date');
+            expect(day).toHaveProperty('hours');
+            expect(day).toHaveProperty('level');
+            expect(day.date instanceof Date).toBe(true);
+            expect(typeof day.hours).toBe('number');
+            expect([0, 1, 2, 3, 4]).toContain(day.level);
+          }
+        }
+      }
+    });
+  });
+});

--- a/src/utils/analytics.ts
+++ b/src/utils/analytics.ts
@@ -21,6 +21,9 @@ export {
   calculateMonthlyProgress,
   calculateMonthlyTargetHours,
   getPreviousMonthProjectDistribution,
+  calculateTotalMonthlyTarget,
+  calculateRemainingWorkingDays,
+  calculateMonthOverMonthChange,
   // Predictions
   predictCompletionDate,
   calculateRecommendedDailyHours,

--- a/src/utils/analytics/heatmap.ts
+++ b/src/utils/analytics/heatmap.ts
@@ -1,0 +1,119 @@
+import { TimeEntry } from '../../types';
+import { getDailyWorkHours } from './daily';
+
+/**
+ * ヒートマップの1日分のデータ
+ */
+export interface HeatmapDay {
+  date: Date;
+  hours: number;
+  level: 0 | 1 | 2 | 3 | 4;
+}
+
+/**
+ * ヒートマップの1週間分のデータ
+ */
+export interface HeatmapWeek {
+  days: (HeatmapDay | null)[];
+}
+
+/**
+ * 作業時間からヒートマップのレベル（0-4）を計算
+ * - 0: 0時間
+ * - 1: 0.1〜2時間未満
+ * - 2: 2〜4時間未満
+ * - 3: 4〜6時間未満
+ * - 4: 6時間以上
+ */
+export const calculateHeatmapLevel = (hours: number): 0 | 1 | 2 | 3 | 4 => {
+  if (hours === 0) return 0;
+  if (hours < 2) return 1;
+  if (hours < 4) return 2;
+  if (hours < 6) return 3;
+  return 4;
+};
+
+/**
+ * 12ヶ月のローリング期間を取得
+ * 今日を終了日として、1年前の翌日を開始日とする
+ */
+export const getRolling12MonthRange = (): { start: Date; end: Date } => {
+  const end = new Date();
+  end.setHours(23, 59, 59, 999);
+
+  const start = new Date();
+  start.setFullYear(start.getFullYear() - 1);
+  start.setDate(start.getDate() + 1);
+  start.setHours(0, 0, 0, 0);
+
+  return { start, end };
+};
+
+/**
+ * 指定期間のヒートマップデータを生成
+ * 週ごとにグループ化し、日曜始まり（GitHub風）の構造で返す
+ */
+export const generateHeatmapData = (
+  timeEntries: TimeEntry[],
+  startDate: Date,
+  endDate: Date
+): HeatmapWeek[] => {
+  const weeks: HeatmapWeek[] = [];
+
+  // 開始日を日曜日に調整
+  const adjustedStart = new Date(startDate);
+  adjustedStart.setHours(0, 0, 0, 0);
+  const dayOfWeek = adjustedStart.getDay();
+  if (dayOfWeek !== 0) {
+    adjustedStart.setDate(adjustedStart.getDate() - dayOfWeek);
+  }
+
+  // 終了日を土曜日に調整
+  const adjustedEnd = new Date(endDate);
+  adjustedEnd.setHours(23, 59, 59, 999);
+  const endDayOfWeek = adjustedEnd.getDay();
+  if (endDayOfWeek !== 6) {
+    adjustedEnd.setDate(adjustedEnd.getDate() + (6 - endDayOfWeek));
+  }
+
+  // 日ごとにデータを生成
+  const currentDate = new Date(adjustedStart);
+  let currentWeek: (HeatmapDay | null)[] = [];
+
+  while (currentDate <= adjustedEnd) {
+    // 期間内かどうかをチェック
+    const isInRange = currentDate >= startDate && currentDate <= endDate;
+
+    if (isInRange) {
+      const hours = getDailyWorkHours(timeEntries, new Date(currentDate));
+      const level = calculateHeatmapLevel(hours);
+
+      currentWeek.push({
+        date: new Date(currentDate),
+        hours,
+        level,
+      });
+    } else {
+      currentWeek.push(null);
+    }
+
+    // 土曜日の場合、週を完了
+    if (currentDate.getDay() === 6) {
+      weeks.push({ days: currentWeek });
+      currentWeek = [];
+    }
+
+    currentDate.setDate(currentDate.getDate() + 1);
+  }
+
+  // 残りの日があれば追加
+  if (currentWeek.length > 0) {
+    // 7日になるまでnullで埋める
+    while (currentWeek.length < 7) {
+      currentWeek.push(null);
+    }
+    weeks.push({ days: currentWeek });
+  }
+
+  return weeks;
+};

--- a/src/utils/analytics/index.ts
+++ b/src/utils/analytics/index.ts
@@ -18,6 +18,9 @@ export {
   calculateMonthlyProgress,
   calculateMonthlyTargetHours,
   getPreviousMonthProjectDistribution,
+  calculateTotalMonthlyTarget,
+  calculateRemainingWorkingDays,
+  calculateMonthOverMonthChange,
 } from './monthly';
 
 // Predictions
@@ -33,3 +36,11 @@ export {
   getMostActiveProject,
   calculateProjectHours,
 } from './aggregations';
+
+// Heatmap
+export {
+  calculateHeatmapLevel,
+  getRolling12MonthRange,
+  generateHeatmapData,
+} from './heatmap';
+export type { HeatmapDay, HeatmapWeek } from './heatmap';


### PR DESCRIPTION
## Summary

- **MonthlyProgressSummary**: 月間進捗サマリーコンポーネントを追加
  - 大きなプログレスリングで進捗率を視覚的に表示
  - 作業時間 / 目標時間の表示
  - 残り営業日数の表示
  - 必要ペース（残り時間/残り日数）の表示
  - 先月比（トレンド付き）の表示

- **ActivityHeatmap**: GitHub風の活動ヒートマップを追加
  - 12ヶ月ローリング表示
  - テーマに合わせた青系カラーパレット
  - ライトモード: 活動多い→濃い色
  - ダークモード: 活動多い→明るく目立つ
  - ホバーでツールチップ表示

- **新規ユーティリティ**:
  - `heatmap.ts`: ヒートマップレベル計算、データ生成
  - `monthly.ts`に追加: `calculateTotalMonthlyTarget`, `calculateRemainingWorkingDays`, `calculateMonthOverMonthChange`

## Test plan

- [x] 全232テスト通過
- [x] リントエラーなし
- [x] ビルド成功
- [ ] ライトモード/ダークモードで表示確認
- [ ] モバイルレスポンシブ確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)