### PR TITLE
test(phase-3-1): backupUtilsとsafeImportUtilsのテスト追加

### DIFF
--- a/docs/refactoring/phased-refactoring-plan-2026.md
+++ b/docs/refactoring/phased-refactoring-plan-2026.md
@@ -326,15 +326,24 @@ src/components/timer/
 ## Phase 3: テストカバレッジ向上
 
 **目的**: コード品質の保証とリグレッション防止
+**ステータス**: P3-1完了
 
-### P3-1: 重要ユーティリティのテスト追加
+### P3-1: 重要ユーティリティのテスト追加 ✅
 
 **優先度: 高**
 
-| ファイル                       | 現在のカバレッジ | 目標 |
-| ------------------------------ | ---------------- | ---- |
-| `src/utils/backupUtils.ts`     | 0%               | 90%  |
-| `src/utils/safeImportUtils.ts` | 0%               | 90%  |
+| ファイル                       | 以前のカバレッジ | 目標 | 結果 |
+| ------------------------------ | ---------------- | ---- | ---- |
+| `src/utils/backupUtils.ts`     | 0%               | 90%  | 100% |
+| `src/utils/safeImportUtils.ts` | 0%               | 90%  | 100% |
+
+**追加テスト**:
+
+- `src/utils/__tests__/backupUtils.test.ts` - 13テスト
+  - createBackup: 7テスト（正常系4、異常系3）
+  - restoreFromBackup: 6テスト（正常系3、異常系3）
+- `src/utils/__tests__/safeImportUtils.test.ts` - 9テスト
+  - safeImportWorkLog: 9テスト（正常系5、異常系4）
 
 **テスト観点**:
 

--- a/src/utils/__tests__/backupUtils.test.ts
+++ b/src/utils/__tests__/backupUtils.test.ts
@@ -1,0 +1,253 @@
+import { createBackup, restoreFromBackup } from '../backupUtils';
+
+// window.electronAPI のモック
+const mockGetUserDataPath = jest.fn();
+const mockCreateDirectory = jest.fn();
+const mockLoadProjects = jest.fn();
+const mockLoadTimeEntries = jest.fn();
+const mockWriteFile = jest.fn();
+const mockReadFile = jest.fn();
+const mockSaveProjects = jest.fn();
+const mockSaveTimeEntries = jest.fn();
+
+beforeAll(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    value: {
+      getUserDataPath: mockGetUserDataPath,
+      createDirectory: mockCreateDirectory,
+      loadProjects: mockLoadProjects,
+      loadTimeEntries: mockLoadTimeEntries,
+      writeFile: mockWriteFile,
+      readFile: mockReadFile,
+      saveProjects: mockSaveProjects,
+      saveTimeEntries: mockSaveTimeEntries,
+    },
+    writable: true,
+  });
+});
+
+describe('backupUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('createBackup', () => {
+    const mockProjects = [
+      {
+        id: '1',
+        name: 'Project A',
+        description: 'Description A',
+        monthlyCapacity: 50,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        isArchived: false,
+      },
+    ];
+
+    const mockTimeEntries = [
+      {
+        id: 'entry-1',
+        projectId: '1',
+        startTime: '2026-01-01T09:00:00Z',
+        endTime: '2026-01-01T12:00:00Z',
+        description: 'Morning work',
+        createdAt: '2026-01-01T09:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+      },
+    ];
+
+    it('バックアップが正常に作成される', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockResolvedValueOnce(mockProjects);
+      mockLoadTimeEntries.mockResolvedValueOnce(mockTimeEntries);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      const result = await createBackup();
+
+      expect(result.success).toBe(true);
+      expect(result.backupPath).toContain('/user/data/backups/');
+      expect(result.projects).toEqual(mockProjects);
+      expect(result.timeEntries).toEqual(mockTimeEntries);
+    });
+
+    it('バックアップディレクトリが作成される', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockResolvedValueOnce(mockProjects);
+      mockLoadTimeEntries.mockResolvedValueOnce(mockTimeEntries);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await createBackup();
+
+      expect(mockCreateDirectory).toHaveBeenCalledTimes(1);
+      expect(mockCreateDirectory.mock.calls[0][0]).toMatch(
+        /\/user\/data\/backups\/\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}/
+      );
+    });
+
+    it('プロジェクトデータがJSONファイルに保存される', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockResolvedValueOnce(mockProjects);
+      mockLoadTimeEntries.mockResolvedValueOnce(mockTimeEntries);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await createBackup();
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('/projects.json'),
+        JSON.stringify(mockProjects, null, 2)
+      );
+    });
+
+    it('タイムエントリデータがJSONファイルに保存される', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockResolvedValueOnce(mockProjects);
+      mockLoadTimeEntries.mockResolvedValueOnce(mockTimeEntries);
+      mockWriteFile.mockResolvedValue(undefined);
+
+      await createBackup();
+
+      expect(mockWriteFile).toHaveBeenCalledWith(
+        expect.stringContaining('/timeEntries.json'),
+        JSON.stringify(mockTimeEntries, null, 2)
+      );
+    });
+
+    it('ディレクトリ作成に失敗した場合、エラーを返す', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockRejectedValueOnce(new Error('Permission denied'));
+
+      const result = await createBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('ファイル書き込みに失敗した場合、エラーを返す', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockResolvedValueOnce(mockProjects);
+      mockLoadTimeEntries.mockResolvedValueOnce(mockTimeEntries);
+      mockWriteFile.mockRejectedValueOnce(new Error('Disk full'));
+
+      const result = await createBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('データ読み込みに失敗した場合、エラーを返す', async () => {
+      mockGetUserDataPath.mockResolvedValueOnce('/user/data');
+      mockCreateDirectory.mockResolvedValueOnce(undefined);
+      mockLoadProjects.mockRejectedValueOnce(new Error('Data corrupted'));
+
+      const result = await createBackup();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+
+  describe('restoreFromBackup', () => {
+    const mockProjects = [
+      {
+        id: '1',
+        name: 'Project A',
+        description: 'Description A',
+        monthlyCapacity: 50,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        isArchived: false,
+      },
+    ];
+
+    const mockTimeEntries = [
+      {
+        id: 'entry-1',
+        projectId: '1',
+        startTime: '2026-01-01T09:00:00Z',
+        endTime: '2026-01-01T12:00:00Z',
+        description: 'Morning work',
+        createdAt: '2026-01-01T09:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+      },
+    ];
+
+    it('バックアップからデータが正常に復元される', async () => {
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(mockProjects))
+        .mockResolvedValueOnce(JSON.stringify(mockTimeEntries));
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const result = await restoreFromBackup('/backup/2026-01-01');
+
+      expect(result.success).toBe(true);
+    });
+
+    it('正しいパスからファイルを読み込む', async () => {
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(mockProjects))
+        .mockResolvedValueOnce(JSON.stringify(mockTimeEntries));
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      await restoreFromBackup('/backup/2026-01-01');
+
+      expect(mockReadFile).toHaveBeenCalledWith(
+        '/backup/2026-01-01/projects.json',
+        { encoding: 'utf8' }
+      );
+      expect(mockReadFile).toHaveBeenCalledWith(
+        '/backup/2026-01-01/timeEntries.json',
+        { encoding: 'utf8' }
+      );
+    });
+
+    it('復元したデータが保存される', async () => {
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(mockProjects))
+        .mockResolvedValueOnce(JSON.stringify(mockTimeEntries));
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      await restoreFromBackup('/backup/2026-01-01');
+
+      expect(mockSaveProjects).toHaveBeenCalledWith(mockProjects);
+      expect(mockSaveTimeEntries).toHaveBeenCalledWith(mockTimeEntries);
+    });
+
+    it('バックアップファイルが存在しない場合、エラーを返す', async () => {
+      mockReadFile.mockRejectedValueOnce(new Error('File not found'));
+
+      const result = await restoreFromBackup('/backup/nonexistent');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('JSONパースに失敗した場合、エラーを返す', async () => {
+      mockReadFile.mockResolvedValueOnce('invalid json');
+
+      const result = await restoreFromBackup('/backup/2026-01-01');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('データ保存に失敗した場合、エラーを返す', async () => {
+      mockReadFile
+        .mockResolvedValueOnce(JSON.stringify(mockProjects))
+        .mockResolvedValueOnce(JSON.stringify(mockTimeEntries));
+      mockSaveProjects.mockRejectedValueOnce(new Error('Save failed'));
+
+      const result = await restoreFromBackup('/backup/2026-01-01');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+  });
+});

--- a/src/utils/__tests__/safeImportUtils.test.ts
+++ b/src/utils/__tests__/safeImportUtils.test.ts
@@ -1,0 +1,324 @@
+import { safeImportWorkLog } from '../safeImportUtils';
+import { createBackup, restoreFromBackup } from '../backupUtils';
+import { importWorkLog } from '../importUtils';
+import { Project, TimeEntry } from '../../types';
+
+// backupUtilsとimportUtilsをモック
+jest.mock('../backupUtils');
+jest.mock('../importUtils');
+
+const mockCreateBackup = createBackup as jest.MockedFunction<
+  typeof createBackup
+>;
+const mockRestoreFromBackup = restoreFromBackup as jest.MockedFunction<
+  typeof restoreFromBackup
+>;
+const mockImportWorkLog = importWorkLog as jest.MockedFunction<
+  typeof importWorkLog
+>;
+
+// window.electronAPI のモック
+const mockSaveProjects = jest.fn();
+const mockSaveTimeEntries = jest.fn();
+
+beforeAll(() => {
+  Object.defineProperty(window, 'electronAPI', {
+    value: {
+      saveProjects: mockSaveProjects,
+      saveTimeEntries: mockSaveTimeEntries,
+    },
+    writable: true,
+  });
+});
+
+describe('safeImportUtils', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('safeImportWorkLog', () => {
+    const mockCurrentProjects: Project[] = [
+      {
+        id: 'existing-1',
+        name: 'Existing Project',
+        description: 'Existing description',
+        monthlyCapacity: 50,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        isArchived: false,
+      },
+    ];
+
+    const mockCurrentTimeEntries: TimeEntry[] = [
+      {
+        id: 'entry-1',
+        projectId: 'existing-1',
+        startTime: '2026-01-01T09:00:00Z',
+        endTime: '2026-01-01T12:00:00Z',
+        description: 'Existing work',
+        createdAt: '2026-01-01T09:00:00Z',
+        updatedAt: '2026-01-01T12:00:00Z',
+      },
+    ];
+
+    const mockImportedProjects: Project[] = [
+      ...mockCurrentProjects,
+      {
+        id: 'new-1',
+        name: 'Imported Project',
+        description: 'Imported description',
+        monthlyCapacity: 1,
+        createdAt: '2026-01-02T00:00:00Z',
+        updatedAt: '2026-01-02T00:00:00Z',
+        isArchived: false,
+      },
+    ];
+
+    const mockImportedTimeEntries: TimeEntry[] = [
+      ...mockCurrentTimeEntries,
+      {
+        id: 'entry-2',
+        projectId: 'new-1',
+        startTime: '2026-01-02T10:00:00Z',
+        endTime: '2026-01-02T15:00:00Z',
+        description: 'Imported work',
+        createdAt: '2026-01-02T10:00:00Z',
+        updatedAt: '2026-01-02T15:00:00Z',
+      },
+    ];
+
+    it('正常にインポートが完了する', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const onSuccess = jest.fn();
+
+      const result = await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(result.success).toBe(true);
+      expect(result.backupPath).toBe('/backup/2026-01-01');
+    });
+
+    it('バックアップが作成される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const onSuccess = jest.fn();
+
+      await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(mockCreateBackup).toHaveBeenCalledTimes(1);
+    });
+
+    it('インポート結果が保存される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const onSuccess = jest.fn();
+
+      await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(mockSaveProjects).toHaveBeenCalledWith(mockImportedProjects);
+      expect(mockSaveTimeEntries).toHaveBeenCalledWith(mockImportedTimeEntries);
+    });
+
+    it('成功コールバックが呼ばれる', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const onSuccess = jest.fn();
+
+      await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(onSuccess).toHaveBeenCalledWith(
+        mockImportedProjects,
+        mockImportedTimeEntries
+      );
+    });
+
+    it('バックアップ作成に失敗した場合、エラーを返す', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: false,
+        error: new Error('Backup failed'),
+      });
+
+      const onSuccess = jest.fn();
+
+      const result = await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(result.success).toBe(false);
+      expect(onSuccess).not.toHaveBeenCalled();
+    });
+
+    it('インポートに失敗した場合、バックアップから復元される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockRejectedValueOnce(new Error('Import failed'));
+      mockRestoreFromBackup.mockResolvedValueOnce({ success: true });
+
+      const onSuccess = jest.fn();
+
+      const result = await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockRestoreFromBackup).toHaveBeenCalledWith('/backup/2026-01-01');
+    });
+
+    it('データ保存に失敗した場合、バックアップから復元される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockRejectedValueOnce(new Error('Save failed'));
+      mockRestoreFromBackup.mockResolvedValueOnce({ success: true });
+
+      const onSuccess = jest.fn();
+
+      const result = await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(result.success).toBe(false);
+      expect(mockRestoreFromBackup).toHaveBeenCalledWith('/backup/2026-01-01');
+    });
+
+    it('復元に失敗しても結果はエラーとして返される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockRejectedValueOnce(new Error('Import failed'));
+      mockRestoreFromBackup.mockResolvedValueOnce({
+        success: false,
+        error: new Error('Restore failed'),
+      });
+
+      const onSuccess = jest.fn();
+
+      const result = await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBeDefined();
+    });
+
+    it('importWorkLogに正しい引数が渡される', async () => {
+      mockCreateBackup.mockResolvedValueOnce({
+        success: true,
+        backupPath: '/backup/2026-01-01',
+        projects: mockCurrentProjects,
+        timeEntries: mockCurrentTimeEntries,
+      });
+      mockImportWorkLog.mockResolvedValueOnce({
+        projects: mockImportedProjects,
+        timeEntries: mockImportedTimeEntries,
+      });
+      mockSaveProjects.mockResolvedValueOnce(undefined);
+      mockSaveTimeEntries.mockResolvedValueOnce(undefined);
+
+      const onSuccess = jest.fn();
+
+      await safeImportWorkLog(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries,
+        onSuccess
+      );
+
+      expect(mockImportWorkLog).toHaveBeenCalledWith(
+        '/path/to/file.csv',
+        mockCurrentProjects,
+        mockCurrentTimeEntries
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- backupUtils.tsとsafeImportUtils.tsのユニットテストを追加
- 両ファイルのテストカバレッジを0%から100%に向上
- Phase 3-1（重要ユーティリティのテスト追加）を完了

## Changes

### 新規テストファイル
- `src/utils/__tests__/backupUtils.test.ts` - 13テスト
  - createBackup: 7テスト（正常系4、異常系3）
  - restoreFromBackup: 6テスト（正常系3、異常系3）
- `src/utils/__tests__/safeImportUtils.test.ts` - 9テスト
  - safeImportWorkLog: 正常系5、異常系4（バックアップ失敗、インポート失敗、保存失敗、復元失敗）

### テスト結果
- 全343テスト合格
- 対象ファイルのカバレッジ: 100%

## Test plan

- [x] `npm test` - 全テスト合格
- [x] `npm run lint` - エラーなし
- [x] `npm run build` - ビルド成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)