### PR TITLE
test(phase-3-2): ダッシュボードコンポーネントのテスト追加

### DIFF
--- a/src/components/comparison/__tests__/ProjectComparisonView.test.tsx
+++ b/src/components/comparison/__tests__/ProjectComparisonView.test.tsx
@@ -283,7 +283,7 @@ describe('ProjectComparisonView', () => {
   });
 
   describe('空データの処理', () => {
-    it('プロジェクトが選択されていない場合にメッセージが表示される', () => {
+    it('activeProjectsが空の場合、自動的にプロジェクトが選択される', async () => {
       renderWithTheme(
         <ProjectComparisonView
           projects={mockProjects}
@@ -292,8 +292,13 @@ describe('ProjectComparisonView', () => {
         />
       );
 
-      // 初期選択で自動選択されるので、空にはならない
-      // ただし、全てアーカイブされている場合は空になる
+      // 自動選択により、プロジェクト詳細が表示されることを確認
+      await waitFor(() => {
+        expect(screen.getByText('プロジェクト詳細')).toBeInTheDocument();
+      });
+
+      // 棒グラフも表示される
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
     });
 
     it('タイムエントリーがなくてもエラーなくレンダリングされる', () => {

--- a/src/components/comparison/__tests__/ProjectComparisonView.test.tsx
+++ b/src/components/comparison/__tests__/ProjectComparisonView.test.tsx
@@ -1,0 +1,351 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { ProjectComparisonView } from '../ProjectComparisonView';
+import {
+  createMockProject,
+  createMockTimeEntry,
+} from '../../../__mocks__/electron';
+import { Project, TimeEntry } from '../../../types';
+
+// Recharts のモック
+jest.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: ({ dataKey }: { dataKey: string }) => (
+    <div data-testid={`bar-${dataKey}`} />
+  ),
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => <div data-testid="cell" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+const theme = createTheme();
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+describe('ProjectComparisonView', () => {
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  const mockProjects: Project[] = [
+    createMockProject({
+      id: 'project-1',
+      name: 'Project A',
+      isArchived: false,
+      monthlyCapacity: 40,
+    }),
+    createMockProject({
+      id: 'project-2',
+      name: 'Project B',
+      isArchived: false,
+      monthlyCapacity: 30,
+    }),
+    createMockProject({
+      id: 'project-3',
+      name: 'Project C',
+      isArchived: false,
+      monthlyCapacity: 20,
+    }),
+    createMockProject({
+      id: 'archived-project',
+      name: 'Archived Project',
+      isArchived: true,
+      monthlyCapacity: 10,
+    }),
+  ];
+
+  const mockTimeEntries: TimeEntry[] = [
+    createMockTimeEntry({
+      id: 'entry-1',
+      projectId: 'project-1',
+      startTime: new Date(currentYear, currentMonth, 5, 9, 0).toISOString(),
+      endTime: new Date(currentYear, currentMonth, 5, 17, 0).toISOString(),
+    }),
+    createMockTimeEntry({
+      id: 'entry-2',
+      projectId: 'project-2',
+      startTime: new Date(currentYear, currentMonth, 6, 10, 0).toISOString(),
+      endTime: new Date(currentYear, currentMonth, 6, 15, 0).toISOString(),
+    }),
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('タイトルが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      expect(screen.getByText('プロジェクト比較')).toBeInTheDocument();
+    });
+
+    it('サブタイトルが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      expect(
+        screen.getByText('複数プロジェクトの進捗状況を比較')
+      ).toBeInTheDocument();
+    });
+
+    it('表示モード切り替えボタンが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      expect(screen.getByTestId('DonutLargeIcon')).toBeInTheDocument();
+    });
+  });
+
+  describe('プロジェクト選択', () => {
+    it('プロジェクト選択セレクターが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      expect(screen.getByLabelText(/比較するプロジェクト/)).toBeInTheDocument();
+    });
+
+    it('アーカイブされていないプロジェクトのみが選択肢に表示される', async () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      // セレクターをクリック
+      const selector = screen.getByRole('combobox');
+      fireEvent.mouseDown(selector);
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('option', { name: 'Project A' })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', { name: 'Project B' })
+        ).toBeInTheDocument();
+        expect(
+          screen.getByRole('option', { name: 'Project C' })
+        ).toBeInTheDocument();
+        expect(
+          screen.queryByRole('option', { name: 'Archived Project' })
+        ).not.toBeInTheDocument();
+      });
+    });
+
+    it('自動的に最大5つのプロジェクトが選択される', () => {
+      const manyProjects = Array.from({ length: 7 }, (_, i) =>
+        createMockProject({
+          id: `project-${i + 1}`,
+          name: `Project ${i + 1}`,
+          isArchived: false,
+        })
+      );
+
+      renderWithTheme(
+        <ProjectComparisonView projects={manyProjects} timeEntries={[]} />
+      );
+
+      // 選択されたプロジェクトのチップを確認
+      const chips = screen
+        .getAllByRole('button')
+        .filter((btn) => btn.classList.contains('MuiChip-root'));
+      // チップの数は最大5つのはず
+      expect(chips.length).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe('グラフ表示', () => {
+    it('デフォルトで棒グラフが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    it('表示モードを切り替えると円グラフが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      const toggleButton = screen
+        .getByTestId('DonutLargeIcon')
+        .closest('button')!;
+      fireEvent.click(toggleButton);
+
+      expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    });
+
+    it('再度切り替えると棒グラフに戻る', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      const toggleButton = screen
+        .getByTestId('DonutLargeIcon')
+        .closest('button')!;
+
+      // 円グラフに切り替え
+      fireEvent.click(toggleButton);
+      expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+
+      // 棒グラフに戻す
+      const viewWeekButton = screen
+        .getByTestId('ViewWeekIcon')
+        .closest('button')!;
+      fireEvent.click(viewWeekButton);
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+  });
+
+  describe('プロジェクト詳細', () => {
+    it('プロジェクト詳細セクションが表示される', async () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText('プロジェクト詳細')).toBeInTheDocument();
+      });
+    });
+
+    it('進捗率が表示される', async () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/進捗:/)[0]).toBeInTheDocument();
+      });
+    });
+
+    it('実績と目標が表示される', async () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getAllByText(/実績:/)[0]).toBeInTheDocument();
+        expect(screen.getAllByText(/目標:/)[0]).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('空データの処理', () => {
+    it('プロジェクトが選択されていない場合にメッセージが表示される', () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          activeProjects={[]}
+        />
+      );
+
+      // 初期選択で自動選択されるので、空にはならない
+      // ただし、全てアーカイブされている場合は空になる
+    });
+
+    it('タイムエントリーがなくてもエラーなくレンダリングされる', () => {
+      renderWithTheme(
+        <ProjectComparisonView projects={mockProjects} timeEntries={[]} />
+      );
+
+      expect(screen.getByText('プロジェクト比較')).toBeInTheDocument();
+    });
+
+    it('アーカイブプロジェクトのみの場合、選択メッセージが表示される', () => {
+      const archivedOnlyProjects = [
+        createMockProject({
+          id: 'archived-1',
+          name: 'Archived 1',
+          isArchived: true,
+        }),
+        createMockProject({
+          id: 'archived-2',
+          name: 'Archived 2',
+          isArchived: true,
+        }),
+      ];
+
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={archivedOnlyProjects}
+          timeEntries={[]}
+        />
+      );
+
+      expect(
+        screen.getByText('比較するプロジェクトを選択してください')
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('activeProjects プロパティ', () => {
+    it('activeProjectsが指定された場合、その順序で選択される', async () => {
+      renderWithTheme(
+        <ProjectComparisonView
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          activeProjects={['project-2', 'project-1']}
+        />
+      );
+
+      await waitFor(() => {
+        // project-2が最初に表示されていることを確認
+        const projectDetails = screen.getAllByText(/Project [AB]/);
+        expect(projectDetails.length).toBeGreaterThan(0);
+      });
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/ActivityHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/ActivityHeatmap.test.tsx
@@ -1,0 +1,219 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { ActivityHeatmap } from '../ActivityHeatmap';
+import { createMockTimeEntry } from '../../../__mocks__/electron';
+import { TimeEntry } from '../../../types';
+import { LanguageContext } from '../../../contexts/LanguageContext';
+import { HeatmapWeek, HeatmapDay } from '../../../utils/analytics/heatmap';
+
+// framer-motion のモック
+jest.mock('framer-motion', () => ({
+  motion: {
+    div: ({
+      children,
+      ...props
+    }: React.PropsWithChildren<Record<string, unknown>>) => (
+      <div {...props}>{children}</div>
+    ),
+  },
+}));
+
+// heatmap utils のモック
+const mockHeatmapData: HeatmapWeek[] = [
+  {
+    days: [
+      { date: new Date(2026, 0, 5), hours: 0, level: 0 },
+      { date: new Date(2026, 0, 6), hours: 2.5, level: 2 },
+      { date: new Date(2026, 0, 7), hours: 5, level: 3 },
+      { date: new Date(2026, 0, 8), hours: 0, level: 0 },
+      { date: new Date(2026, 0, 9), hours: 1.5, level: 1 },
+      { date: new Date(2026, 0, 10), hours: 8, level: 4 },
+      { date: new Date(2026, 0, 11), hours: 0, level: 0 },
+    ] as HeatmapDay[],
+  },
+  {
+    days: [
+      { date: new Date(2026, 0, 12), hours: 3, level: 2 },
+      { date: new Date(2026, 0, 13), hours: 0, level: 0 },
+      null,
+      null,
+      null,
+      null,
+      null,
+    ],
+  },
+];
+
+jest.mock('../../../utils/analytics/heatmap', () => ({
+  generateHeatmapData: jest.fn(() => mockHeatmapData),
+  getRolling12MonthRange: jest.fn(() => ({
+    start: new Date(2025, 0, 6),
+    end: new Date(2026, 0, 5),
+  })),
+  calculateHeatmapLevel: jest.fn((hours: number) => {
+    if (hours === 0) return 0;
+    if (hours < 2) return 1;
+    if (hours < 4) return 2;
+    if (hours < 6) return 3;
+    return 4;
+  }),
+}));
+
+// GlassCard のモック
+jest.mock('../../ui/modern/StyledComponents', () => ({
+  GlassCard: ({ children, sx }: { children: React.ReactNode; sx?: object }) => (
+    <div data-testid="glass-card" style={sx as React.CSSProperties}>
+      {children}
+    </div>
+  ),
+}));
+
+const theme = createTheme();
+
+const mockTranslations: Record<string, string> = {
+  'dashboard.heatmap.title': '活動ヒートマップ',
+  'dashboard.heatmap.less': '少',
+  'dashboard.heatmap.more': '多',
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  language: 'ja' | 'en' = 'ja'
+) => {
+  const languageContextValue = {
+    language,
+    setLanguage: jest.fn(),
+    t: (key: string) => mockTranslations[key] || key,
+  };
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <LanguageContext.Provider value={languageContextValue}>
+        {ui}
+      </LanguageContext.Provider>
+    </ThemeProvider>
+  );
+};
+
+describe('ActivityHeatmap', () => {
+  const mockTimeEntries: TimeEntry[] = [
+    createMockTimeEntry({
+      id: 'entry-1',
+      projectId: 'project-1',
+      startTime: '2026-01-06T09:00:00Z',
+      endTime: '2026-01-06T11:30:00Z',
+    }),
+    createMockTimeEntry({
+      id: 'entry-2',
+      projectId: 'project-1',
+      startTime: '2026-01-07T09:00:00Z',
+      endTime: '2026-01-07T14:00:00Z',
+    }),
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('タイトルが表示される', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      expect(screen.getByText('活動ヒートマップ')).toBeInTheDocument();
+    });
+
+    it('GlassCardでラップされる', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      expect(screen.getByTestId('glass-card')).toBeInTheDocument();
+    });
+
+    it('凡例が表示される', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      expect(screen.getByText('少')).toBeInTheDocument();
+      expect(screen.getByText('多')).toBeInTheDocument();
+    });
+  });
+
+  describe('ヒートマップセル', () => {
+    it('ヒートマップセルが表示される', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      // aria-label を持つセルを探す
+      const cells = screen
+        .getAllByRole('generic')
+        .filter(
+          (el) =>
+            el.getAttribute('aria-label')?.includes('時間') ||
+            el.getAttribute('aria-label')?.includes('hours')
+        );
+
+      expect(cells.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('曜日ラベル', () => {
+    it('日本語モードで曜日ラベルが表示される', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      expect(screen.getByText('月')).toBeInTheDocument();
+      expect(screen.getByText('水')).toBeInTheDocument();
+      expect(screen.getByText('金')).toBeInTheDocument();
+    });
+
+    it('英語モードで曜日ラベルが表示される', () => {
+      renderWithProviders(
+        <ActivityHeatmap timeEntries={mockTimeEntries} />,
+        'en'
+      );
+
+      expect(screen.getByText('Mon')).toBeInTheDocument();
+      expect(screen.getByText('Wed')).toBeInTheDocument();
+      expect(screen.getByText('Fri')).toBeInTheDocument();
+    });
+  });
+
+  describe('クリックイベント', () => {
+    it('onDayClickが渡された場合、クリックでコールバックが呼ばれる', () => {
+      const mockOnDayClick = jest.fn();
+
+      renderWithProviders(
+        <ActivityHeatmap
+          timeEntries={mockTimeEntries}
+          onDayClick={mockOnDayClick}
+        />
+      );
+
+      // クリック可能なセルを探してクリック
+      const cells = screen
+        .getAllByRole('generic')
+        .filter((el) => el.getAttribute('aria-label')?.includes('時間'));
+
+      if (cells.length > 0) {
+        fireEvent.click(cells[0]);
+        expect(mockOnDayClick).toHaveBeenCalled();
+      }
+    });
+  });
+
+  describe('空データの処理', () => {
+    it('タイムエントリーが空でもエラーなくレンダリングされる', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={[]} />);
+
+      expect(screen.getByText('活動ヒートマップ')).toBeInTheDocument();
+    });
+  });
+
+  describe('月ラベル', () => {
+    it('月ラベルが表示される', () => {
+      renderWithProviders(<ActivityHeatmap timeEntries={mockTimeEntries} />);
+
+      // 月ラベル（1月など）が表示されていることを確認
+      // モックデータに基づいて1月のラベルが存在するはず
+      const monthLabels = screen.getAllByText(/月/);
+      expect(monthLabels.length).toBeGreaterThan(0);
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/ActivityHeatmap.test.tsx
+++ b/src/components/dashboard/__tests__/ActivityHeatmap.test.tsx
@@ -71,10 +71,17 @@ jest.mock('../../ui/modern/StyledComponents', () => ({
 
 const theme = createTheme();
 
-const mockTranslations: Record<string, string> = {
-  'dashboard.heatmap.title': '活動ヒートマップ',
-  'dashboard.heatmap.less': '少',
-  'dashboard.heatmap.more': '多',
+const mockTranslations: Record<string, Record<string, string>> = {
+  ja: {
+    'dashboard.heatmap.title': '活動ヒートマップ',
+    'dashboard.heatmap.less': '少',
+    'dashboard.heatmap.more': '多',
+  },
+  en: {
+    'dashboard.heatmap.title': 'Activity Heatmap',
+    'dashboard.heatmap.less': 'Less',
+    'dashboard.heatmap.more': 'More',
+  },
 };
 
 const renderWithProviders = (
@@ -84,7 +91,7 @@ const renderWithProviders = (
   const languageContextValue = {
     language,
     setLanguage: jest.fn(),
-    t: (key: string) => mockTranslations[key] || key,
+    t: (key: string) => mockTranslations[language][key] || key,
   };
 
   return render(
@@ -172,6 +179,17 @@ describe('ActivityHeatmap', () => {
       expect(screen.getByText('Mon')).toBeInTheDocument();
       expect(screen.getByText('Wed')).toBeInTheDocument();
       expect(screen.getByText('Fri')).toBeInTheDocument();
+    });
+
+    it('英語モードでタイトルと凡例が英語表示される', () => {
+      renderWithProviders(
+        <ActivityHeatmap timeEntries={mockTimeEntries} />,
+        'en'
+      );
+
+      expect(screen.getByText('Activity Heatmap')).toBeInTheDocument();
+      expect(screen.getByText('Less')).toBeInTheDocument();
+      expect(screen.getByText('More')).toBeInTheDocument();
     });
   });
 

--- a/src/components/dashboard/__tests__/Dashboard.test.tsx
+++ b/src/components/dashboard/__tests__/Dashboard.test.tsx
@@ -1,0 +1,273 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { Dashboard } from '../Dashboard';
+import {
+  createMockProject,
+  createMockTimeEntry,
+} from '../../../__mocks__/electron';
+import { Project, TimeEntry } from '../../../types';
+import { projectColorManager } from '../../../utils/colorUtils';
+
+// 子コンポーネントをモック
+jest.mock('../MonthlyProgressSummary', () => ({
+  MonthlyProgressSummary: ({
+    projects,
+    timeEntries,
+  }: {
+    projects: Project[];
+    timeEntries: TimeEntry[];
+  }) => (
+    <div data-testid="monthly-progress-summary">
+      MonthlyProgressSummary: {projects.length} projects, {timeEntries.length}{' '}
+      entries
+    </div>
+  ),
+}));
+
+jest.mock('../ActivityHeatmap', () => ({
+  ActivityHeatmap: ({ timeEntries }: { timeEntries: TimeEntry[] }) => (
+    <div data-testid="activity-heatmap">
+      ActivityHeatmap: {timeEntries.length} entries
+    </div>
+  ),
+}));
+
+jest.mock('../WeeklySummary', () => ({
+  WeeklySummary: ({
+    projects,
+    timeEntries,
+  }: {
+    projects: Project[];
+    timeEntries: TimeEntry[];
+  }) => (
+    <div data-testid="weekly-summary">
+      WeeklySummary: {projects.length} projects, {timeEntries.length} entries
+    </div>
+  ),
+}));
+
+jest.mock('../MonthlySummary', () => ({
+  MonthlySummary: ({
+    projects,
+    timeEntries,
+  }: {
+    projects: Project[];
+    timeEntries: TimeEntry[];
+  }) => (
+    <div data-testid="monthly-summary">
+      MonthlySummary: {projects.length} projects, {timeEntries.length} entries
+    </div>
+  ),
+}));
+
+jest.mock('../ProjectProgressView', () => ({
+  ProjectProgressView: ({
+    projects,
+    timeEntries,
+    onStartTimer,
+  }: {
+    projects: Project[];
+    timeEntries: TimeEntry[];
+    onStartTimer: (projectId: string) => void;
+  }) => (
+    <div data-testid="project-progress-view">
+      <span>
+        ProjectProgressView: {projects.length} projects, {timeEntries.length}{' '}
+        entries
+      </span>
+      <button onClick={() => onStartTimer('test-id')}>Start Timer</button>
+    </div>
+  ),
+}));
+
+const theme = createTheme();
+
+const renderWithTheme = (ui: React.ReactElement) => {
+  return render(<ThemeProvider theme={theme}>{ui}</ThemeProvider>);
+};
+
+describe('Dashboard', () => {
+  const mockProjects: Project[] = [
+    createMockProject({ id: 'project-1', name: 'Project 1' }),
+    createMockProject({ id: 'project-2', name: 'Project 2' }),
+  ];
+
+  const mockTimeEntries: TimeEntry[] = [
+    createMockTimeEntry({ id: 'entry-1', projectId: 'project-1' }),
+    createMockTimeEntry({ id: 'entry-2', projectId: 'project-2' }),
+  ];
+
+  const mockOnStartTimer = jest.fn();
+  const mockOnEditProject = jest.fn();
+  const mockOnArchiveProject = jest.fn();
+  const mockOnUnarchiveProject = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // projectColorManager の初期化をスパイ
+    jest.spyOn(projectColorManager, 'initializeColors');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('初期レンダリング', () => {
+    it('色の初期化後に全ての子コンポーネントが表示される', async () => {
+      renderWithTheme(
+        <Dashboard
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          onStartTimer={mockOnStartTimer}
+          onEditProject={mockOnEditProject}
+          onArchiveProject={mockOnArchiveProject}
+          onUnarchiveProject={mockOnUnarchiveProject}
+        />
+      );
+
+      // 色の初期化を待つ
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('monthly-progress-summary')
+        ).toBeInTheDocument();
+      });
+
+      expect(screen.getByTestId('activity-heatmap')).toBeInTheDocument();
+      expect(screen.getByTestId('weekly-summary')).toBeInTheDocument();
+      expect(screen.getByTestId('monthly-summary')).toBeInTheDocument();
+      expect(screen.getByTestId('project-progress-view')).toBeInTheDocument();
+    });
+
+    it('projectColorManager.initializeColors が呼ばれる', async () => {
+      renderWithTheme(
+        <Dashboard
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          onStartTimer={mockOnStartTimer}
+        />
+      );
+
+      await waitFor(() => {
+        expect(projectColorManager.initializeColors).toHaveBeenCalledWith(
+          mockProjects
+        );
+      });
+    });
+  });
+
+  describe('プロパティの伝達', () => {
+    it('子コンポーネントにプロジェクトとタイムエントリーが渡される', async () => {
+      renderWithTheme(
+        <Dashboard
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          onStartTimer={mockOnStartTimer}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('monthly-progress-summary')
+        ).toHaveTextContent('2 projects');
+        expect(
+          screen.getByTestId('monthly-progress-summary')
+        ).toHaveTextContent('2 entries');
+      });
+
+      expect(screen.getByTestId('activity-heatmap')).toHaveTextContent(
+        '2 entries'
+      );
+      expect(screen.getByTestId('weekly-summary')).toHaveTextContent(
+        '2 projects'
+      );
+      expect(screen.getByTestId('monthly-summary')).toHaveTextContent(
+        '2 projects'
+      );
+      expect(screen.getByTestId('project-progress-view')).toHaveTextContent(
+        '2 projects'
+      );
+    });
+  });
+
+  describe('空データの処理', () => {
+    it('プロジェクトが空でも正常にレンダリングされる', async () => {
+      renderWithTheme(
+        <Dashboard
+          projects={[]}
+          timeEntries={[]}
+          onStartTimer={mockOnStartTimer}
+        />
+      );
+
+      await waitFor(() => {
+        expect(
+          screen.getByTestId('monthly-progress-summary')
+        ).toHaveTextContent('0 projects');
+      });
+
+      expect(screen.getByTestId('activity-heatmap')).toHaveTextContent(
+        '0 entries'
+      );
+    });
+  });
+
+  describe('イベントハンドリング', () => {
+    it('onStartTimerが子コンポーネントから呼び出せる', async () => {
+      renderWithTheme(
+        <Dashboard
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          onStartTimer={mockOnStartTimer}
+        />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('project-progress-view')).toBeInTheDocument();
+      });
+
+      const startButton = screen.getByRole('button', { name: /start timer/i });
+      startButton.click();
+
+      expect(mockOnStartTimer).toHaveBeenCalledWith('test-id');
+    });
+  });
+
+  describe('プロジェクト変更時の挙動', () => {
+    it('プロジェクトが変更されると色が再初期化される', async () => {
+      const { rerender } = renderWithTheme(
+        <Dashboard
+          projects={mockProjects}
+          timeEntries={mockTimeEntries}
+          onStartTimer={mockOnStartTimer}
+        />
+      );
+
+      await waitFor(() => {
+        expect(projectColorManager.initializeColors).toHaveBeenCalledTimes(1);
+      });
+
+      const newProjects = [
+        ...mockProjects,
+        createMockProject({ id: 'project-3', name: 'Project 3' }),
+      ];
+
+      rerender(
+        <ThemeProvider theme={theme}>
+          <Dashboard
+            projects={newProjects}
+            timeEntries={mockTimeEntries}
+            onStartTimer={mockOnStartTimer}
+          />
+        </ThemeProvider>
+      );
+
+      await waitFor(() => {
+        expect(projectColorManager.initializeColors).toHaveBeenCalledTimes(2);
+        expect(projectColorManager.initializeColors).toHaveBeenLastCalledWith(
+          newProjects
+        );
+      });
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/MonthlySummary.test.tsx
+++ b/src/components/dashboard/__tests__/MonthlySummary.test.tsx
@@ -1,0 +1,257 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { MonthlySummary } from '../MonthlySummary';
+import {
+  createMockProject,
+  createMockTimeEntry,
+} from '../../../__mocks__/electron';
+import { Project, TimeEntry } from '../../../types';
+import { LanguageContext } from '../../../contexts/LanguageContext';
+
+// Recharts のモック
+jest.mock('recharts', () => ({
+  LineChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="line-chart">{children}</div>
+  ),
+  Line: () => <div data-testid="line" />,
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: ({ data }: { data: Array<{ name: string; value: number }> }) => (
+    <div data-testid="pie">
+      {data?.map((item, index) => (
+        <span key={index} data-testid={`pie-data-${index}`}>
+          {item.name}: {item.value}
+        </span>
+      ))}
+    </div>
+  ),
+  Cell: () => <div data-testid="cell" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+// colorUtils のモック
+jest.mock('../../../utils/colorUtils', () => ({
+  projectColorManager: {
+    getColorByName: () => '#0088FE',
+    getColorById: () => '#0088FE',
+    initializeColors: jest.fn(),
+  },
+}));
+
+const theme = createTheme();
+
+const mockTranslations: Record<string, string> = {
+  'dashboard.monthly.title': '月間サマリー',
+  'dashboard.monthly.total': '合計',
+  'units.hours': '時間',
+  'timer.title': '作業時間',
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  language: 'ja' | 'en' = 'ja'
+) => {
+  const languageContextValue = {
+    language,
+    setLanguage: jest.fn(),
+    t: (key: string) => mockTranslations[key] || key,
+  };
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <LanguageContext.Provider value={languageContextValue}>
+        {ui}
+      </LanguageContext.Provider>
+    </ThemeProvider>
+  );
+};
+
+describe('MonthlySummary', () => {
+  const mockProjects: Project[] = [
+    createMockProject({ id: 'project-1', name: 'Project A' }),
+    createMockProject({ id: 'project-2', name: 'Project B' }),
+  ];
+
+  const now = new Date();
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  const mockTimeEntries: TimeEntry[] = [
+    createMockTimeEntry({
+      id: 'entry-1',
+      projectId: 'project-1',
+      startTime: new Date(currentYear, currentMonth, 5, 9, 0).toISOString(),
+      endTime: new Date(currentYear, currentMonth, 5, 11, 0).toISOString(),
+    }),
+    createMockTimeEntry({
+      id: 'entry-2',
+      projectId: 'project-2',
+      startTime: new Date(currentYear, currentMonth, 10, 14, 0).toISOString(),
+      endTime: new Date(currentYear, currentMonth, 10, 17, 0).toISOString(),
+    }),
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('タイトルが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByText('月間サマリー')).toBeInTheDocument();
+    });
+
+    it('合計時間が表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByText(/合計:/)).toBeInTheDocument();
+    });
+
+    it('タブが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(
+        screen.getByRole('tab', { name: /プロジェクト分布/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('tab', { name: /週別推移/i })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('年月セレクター', () => {
+    it('年セレクターが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      // 2つのセレクター（年・月）が表示されることを確認
+      const comboboxes = screen.getAllByRole('combobox');
+      expect(comboboxes.length).toBeGreaterThanOrEqual(2);
+
+      // 現在の年が表示されていることを確認（"2026年"という形式）
+      expect(screen.getByText(`${currentYear}年`)).toBeInTheDocument();
+    });
+
+    it('月セレクターが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      // 月のセレクターが存在することを確認
+      const comboboxes = screen.getAllByRole('combobox');
+      expect(comboboxes.length).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  describe('タブ切り替え', () => {
+    it('デフォルトでプロジェクト分布タブが選択される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      const projectsTab = screen.getByRole('tab', {
+        name: /プロジェクト分布/i,
+      });
+      expect(projectsTab).toHaveAttribute('aria-selected', 'true');
+    });
+
+    it('週別推移タブをクリックすると切り替わる', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      const weeklyTab = screen.getByRole('tab', { name: /週別推移/i });
+      fireEvent.click(weeklyTab);
+
+      expect(weeklyTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('グラフ表示', () => {
+    it('プロジェクト分布タブで円グラフが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    });
+
+    it('週別推移タブで折れ線グラフが表示される', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      const weeklyTab = screen.getByRole('tab', { name: /週別推移/i });
+      fireEvent.click(weeklyTab);
+
+      expect(screen.getByTestId('line-chart')).toBeInTheDocument();
+    });
+  });
+
+  describe('空データの処理', () => {
+    it('データがない場合にメッセージが表示される（プロジェクト分布）', () => {
+      renderWithProviders(<MonthlySummary projects={[]} timeEntries={[]} />);
+
+      expect(
+        screen.getByText(/この月のプロジェクトデータがありません/)
+      ).toBeInTheDocument();
+    });
+
+    it('週別推移タブに切り替え可能', () => {
+      renderWithProviders(
+        <MonthlySummary projects={mockProjects} timeEntries={[]} />
+      );
+
+      const weeklyTab = screen.getByRole('tab', { name: /週別推移/i });
+      fireEvent.click(weeklyTab);
+
+      // タブが選択状態になることを確認
+      expect(weeklyTab).toHaveAttribute('aria-selected', 'true');
+    });
+  });
+
+  describe('英語表示', () => {
+    it('英語モードで正しいラベルが表示される', () => {
+      const languageContextValue = {
+        language: 'en' as const,
+        setLanguage: jest.fn(),
+        t: (key: string) => mockTranslations[key] || key,
+      };
+
+      render(
+        <ThemeProvider theme={theme}>
+          <LanguageContext.Provider value={languageContextValue}>
+            <MonthlySummary
+              projects={mockProjects}
+              timeEntries={mockTimeEntries}
+            />
+          </LanguageContext.Provider>
+        </ThemeProvider>
+      );
+
+      expect(
+        screen.getByRole('tab', { name: /Project Distribution/i })
+      ).toBeInTheDocument();
+      expect(
+        screen.getByRole('tab', { name: /Weekly Trend/i })
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/components/dashboard/__tests__/WeeklySummary.test.tsx
+++ b/src/components/dashboard/__tests__/WeeklySummary.test.tsx
@@ -280,7 +280,11 @@ describe('WeeklySummary', () => {
       );
 
       // 英語形式の日付（例: "Jan 6, 2026 - Jan 12, 2026"）が含まれていることを確認
-      expect(screen.getByText(/-/)).toBeInTheDocument();
+      // 月の短縮名（Jan, Feb, Mar など）と年を含む形式
+      const dateElement = screen.getByText(
+        /[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4}\s+-\s+[A-Z][a-z]{2}\s+\d{1,2},\s+\d{4}/
+      );
+      expect(dateElement).toBeInTheDocument();
     });
   });
 });

--- a/src/components/dashboard/__tests__/WeeklySummary.test.tsx
+++ b/src/components/dashboard/__tests__/WeeklySummary.test.tsx
@@ -1,0 +1,286 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { ThemeProvider, createTheme } from '@mui/material';
+import { WeeklySummary } from '../WeeklySummary';
+import {
+  createMockProject,
+  createMockTimeEntry,
+} from '../../../__mocks__/electron';
+import { Project, TimeEntry } from '../../../types';
+import { LanguageContext } from '../../../contexts/LanguageContext';
+
+// Recharts のモック
+jest.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: ({ dataKey }: { dataKey: string }) => (
+    <div data-testid={`bar-${dataKey}`} />
+  ),
+  XAxis: () => <div data-testid="x-axis" />,
+  YAxis: () => <div data-testid="y-axis" />,
+  CartesianGrid: () => <div data-testid="cartesian-grid" />,
+  Tooltip: () => <div data-testid="tooltip" />,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  PieChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="pie-chart">{children}</div>
+  ),
+  Pie: () => <div data-testid="pie" />,
+  Cell: () => <div data-testid="cell" />,
+  Legend: () => <div data-testid="legend" />,
+}));
+
+// colorUtils のモック
+jest.mock('../../../utils/colorUtils', () => ({
+  projectColorManager: {
+    getColorByName: () => '#0088FE',
+    getColorById: () => '#0088FE',
+    initializeColors: jest.fn(),
+  },
+}));
+
+const theme = createTheme();
+
+const mockTranslations: Record<string, string> = {
+  'dashboard.weekly.title': '週間サマリー',
+  'dashboard.weekly.byproject': 'プロジェクト別',
+  'dashboard.daily.total': '合計',
+  'units.hours': '時間',
+  'time.this.week': '今週',
+  'timer.no.entries': 'エントリーがありません',
+};
+
+const renderWithProviders = (
+  ui: React.ReactElement,
+  language: 'ja' | 'en' = 'ja'
+) => {
+  const languageContextValue = {
+    language,
+    setLanguage: jest.fn(),
+    t: (key: string) => mockTranslations[key] || key,
+  };
+
+  return render(
+    <ThemeProvider theme={theme}>
+      <LanguageContext.Provider value={languageContextValue}>
+        {ui}
+      </LanguageContext.Provider>
+    </ThemeProvider>
+  );
+};
+
+describe('WeeklySummary', () => {
+  const mockProjects: Project[] = [
+    createMockProject({
+      id: 'project-1',
+      name: 'Project A',
+      isArchived: false,
+    }),
+    createMockProject({
+      id: 'project-2',
+      name: 'Project B',
+      isArchived: false,
+    }),
+  ];
+
+  // 今週のデータを作成
+  const getStartOfWeek = () => {
+    const now = new Date();
+    now.setHours(0, 0, 0, 0);
+    const day = now.getDay();
+    const diff = day === 0 ? -6 : 1 - day;
+    const monday = new Date(now);
+    monday.setDate(now.getDate() + diff);
+    return monday;
+  };
+
+  const startOfWeek = getStartOfWeek();
+
+  const mockTimeEntries: TimeEntry[] = [
+    createMockTimeEntry({
+      id: 'entry-1',
+      projectId: 'project-1',
+      startTime: new Date(
+        startOfWeek.getTime() + 9 * 60 * 60 * 1000
+      ).toISOString(),
+      endTime: new Date(
+        startOfWeek.getTime() + 11 * 60 * 60 * 1000
+      ).toISOString(),
+    }),
+    createMockTimeEntry({
+      id: 'entry-2',
+      projectId: 'project-2',
+      startTime: new Date(
+        startOfWeek.getTime() + 24 * 60 * 60 * 1000 + 14 * 60 * 60 * 1000
+      ).toISOString(),
+      endTime: new Date(
+        startOfWeek.getTime() + 24 * 60 * 60 * 1000 + 17 * 60 * 60 * 1000
+      ).toISOString(),
+    }),
+  ];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('基本レンダリング', () => {
+    it('タイトルが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByText('週間サマリー')).toBeInTheDocument();
+    });
+
+    it('今週ボタンが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByRole('button', { name: /今週/i })).toBeInTheDocument();
+    });
+
+    it('週移動ボタンが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByTestId('ChevronLeftIcon')).toBeInTheDocument();
+      expect(screen.getByTestId('ChevronRightIcon')).toBeInTheDocument();
+    });
+
+    it('プロジェクト別サブタイトルが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByText('プロジェクト別')).toBeInTheDocument();
+    });
+  });
+
+  describe('週移動機能', () => {
+    it('左矢印クリックで前週に移動', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      const prevButton = screen
+        .getByTestId('ChevronLeftIcon')
+        .closest('button')!;
+      const initialDateText = screen.getByText(/〜/).textContent;
+
+      fireEvent.click(prevButton);
+
+      const newDateText = screen.getByText(/〜/).textContent;
+      expect(newDateText).not.toBe(initialDateText);
+    });
+
+    it('右矢印クリックで翌週に移動', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      // まず前週に移動
+      const prevButton = screen
+        .getByTestId('ChevronLeftIcon')
+        .closest('button')!;
+      fireEvent.click(prevButton);
+
+      const dateAfterPrev = screen.getByText(/〜/).textContent;
+
+      // 翌週に移動
+      const nextButton = screen
+        .getByTestId('ChevronRightIcon')
+        .closest('button')!;
+      fireEvent.click(nextButton);
+
+      const dateAfterNext = screen.getByText(/〜/).textContent;
+      expect(dateAfterNext).not.toBe(dateAfterPrev);
+    });
+
+    it('今週ボタンクリックで今週に戻る', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      const initialDateText = screen.getByText(/〜/).textContent;
+
+      // 前週に移動
+      const prevButton = screen
+        .getByTestId('ChevronLeftIcon')
+        .closest('button')!;
+      fireEvent.click(prevButton);
+      fireEvent.click(prevButton);
+
+      // 今週に戻る
+      const thisWeekButton = screen.getByRole('button', { name: /今週/i });
+      fireEvent.click(thisWeekButton);
+
+      const currentDateText = screen.getByText(/〜/).textContent;
+      expect(currentDateText).toBe(initialDateText);
+    });
+  });
+
+  describe('グラフ表示', () => {
+    it('棒グラフが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByTestId('bar-chart')).toBeInTheDocument();
+    });
+
+    it('円グラフが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByTestId('pie-chart')).toBeInTheDocument();
+    });
+
+    it('アーカイブされていないプロジェクトのバーが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={mockTimeEntries} />
+      );
+
+      expect(screen.getByTestId('bar-Project A')).toBeInTheDocument();
+      expect(screen.getByTestId('bar-Project B')).toBeInTheDocument();
+    });
+  });
+
+  describe('空データの処理', () => {
+    it('エントリーがない場合にメッセージが表示される', () => {
+      renderWithProviders(
+        <WeeklySummary projects={mockProjects} timeEntries={[]} />
+      );
+
+      expect(screen.getByText('エントリーがありません')).toBeInTheDocument();
+    });
+  });
+
+  describe('英語表示', () => {
+    it('英語モードで週の日付形式が変わる', () => {
+      const languageContextValue = {
+        language: 'en' as const,
+        setLanguage: jest.fn(),
+        t: (key: string) => mockTranslations[key] || key,
+      };
+
+      render(
+        <ThemeProvider theme={theme}>
+          <LanguageContext.Provider value={languageContextValue}>
+            <WeeklySummary
+              projects={mockProjects}
+              timeEntries={mockTimeEntries}
+            />
+          </LanguageContext.Provider>
+        </ThemeProvider>
+      );
+
+      // 英語形式の日付（例: "Jan 6, 2026 - Jan 12, 2026"）が含まれていることを確認
+      expect(screen.getByText(/-/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/contexts/__tests__/SettingsContext.test.tsx
+++ b/src/contexts/__tests__/SettingsContext.test.tsx
@@ -43,10 +43,14 @@ describe('SettingsContext', () => {
       expect(result.current.settings.workHours.baseMonthlyHours).toBe(140);
     });
 
-    it('初期状態ではisLoadingがtrueである', () => {
+    it('初期状態ではisLoadingがtrueである', async () => {
       const { result } = renderHook(() => useSettingsContext(), { wrapper });
 
       expect(result.current.isLoading).toBe(true);
+
+      await waitFor(() => {
+        expect(result.current.isLoading).toBe(false);
+      });
     });
   });
 

--- a/src/utils/__tests__/backupUtils.test.ts
+++ b/src/utils/__tests__/backupUtils.test.ts
@@ -27,8 +27,15 @@ beforeAll(() => {
 });
 
 describe('backupUtils', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('createBackup', () => {

--- a/src/utils/__tests__/safeImportUtils.test.ts
+++ b/src/utils/__tests__/safeImportUtils.test.ts
@@ -32,8 +32,15 @@ beforeAll(() => {
 });
 
 describe('safeImportUtils', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
   });
 
   describe('safeImportWorkLog', () => {


### PR DESCRIPTION
## Summary
- ダッシュボードコンポーネントとProjectComparisonViewのテストを追加
- 合計55件の新規テストを追加（全398テスト合格）
- 対象コンポーネントのカバレッジを大幅に向上

## 対象コンポーネントのカバレッジ
| コンポーネント | カバレッジ |
|--------------|-----------|
| Dashboard.tsx | 86.95% |
| MonthlySummary.tsx | 82% |
| WeeklySummary.tsx | 84.21% |
| ActivityHeatmap.tsx | 98.14% |
| ProjectComparisonView.tsx | 90.74% |

## テスト項目
- 基本レンダリングテスト
- ユーザーインタラクション（タブ切り替え、週移動、表示モード切替）
- 空データの処理
- 多言語対応（日本語/英語）

## Test plan
- [x] 全398テスト合格
- [x] lint 0エラー（30 warnings - 既存のconsole.log警告）
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)